### PR TITLE
Extend Playwright tests for The Internet

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 import os
 os.environ["PW_HEADLESS"] = "false"
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def base_url():
-    return "https://playwright.dev"
+    return "https://the-internet.herokuapp.com"
 

--- a/tests/pages/base_page.py
+++ b/tests/pages/base_page.py
@@ -1,0 +1,9 @@
+from playwright.sync_api import Page
+
+
+class BasePage:
+    def __init__(self, page: Page):
+        self.page = page
+
+    def goto(self, url: str):
+        self.page.goto(url)

--- a/tests/pages/home_page.py
+++ b/tests/pages/home_page.py
@@ -1,17 +1,19 @@
 from playwright.sync_api import Page, expect
+from .base_page import BasePage
 
-class Home_page:
+
+class Home_page(BasePage):
     def __init__(self, page: Page):
-        self.page =page
+        super().__init__(page)
+        self.expected_title = "The Internet"
 
-    def goto(self, base_url):
-        self.page.goto(base_url)
+    def open(self, base_url: str):
+        self.goto(base_url)
 
     def check_title(self):
-        expect(self.page).to_have_title("Fast and reliable end-to-end testing for modern web apps | Playwright")
-        print(self.page.title())
-    
-    def click_elem(self, element):
-        element.click()
+        expect(self.page).to_have_title(self.expected_title)
+
+    def go_to_login(self):
+        self.page.click("text=Form Authentication")
 
 

--- a/tests/pages/login_page.py
+++ b/tests/pages/login_page.py
@@ -1,0 +1,22 @@
+from playwright.sync_api import Page, expect
+from .base_page import BasePage
+
+
+class LoginPage(BasePage):
+    def __init__(self, page: Page):
+        super().__init__(page)
+        self.username_input = page.locator("#username")
+        self.password_input = page.locator("#password")
+        self.login_button = page.locator("button[type=submit]")
+        self.flash_message = page.locator("#flash")
+
+    def open(self, base_url: str):
+        self.goto(f"{base_url}/login")
+
+    def login(self, username: str, password: str):
+        self.username_input.fill(username)
+        self.password_input.fill(password)
+        self.login_button.click()
+
+    def assert_login_success(self):
+        expect(self.flash_message).to_contain_text("You logged into a secure area!")

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,12 +1,13 @@
+from playwright.sync_api import expect
 from .pages.home_page import Home_page
-import time
 
-def test_example(page, base_url):
+
+def test_home_page_navigation(page, base_url):
     home = Home_page(page)
-    home.goto(base_url)
+    home.open(base_url)
     home.check_title()
-    page.click("text=Get Started")
-    page.click("text=Introduction")    
+    home.go_to_login()
+    expect(page).to_have_url(f"{base_url}/login")
     
 
     

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,8 @@
+from .pages.login_page import LoginPage
+
+
+def test_successful_login(page, base_url):
+    login = LoginPage(page)
+    login.open(base_url)
+    login.login("tomsmith", "SuperSecretPassword!")
+    login.assert_login_success()


### PR DESCRIPTION
## Summary
- target `the-internet.herokuapp.com` as base URL
- add BasePage, Home_page, LoginPage page objects
- test navigation from home page to login page
- add successful login test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_687a9a7bc2e0832b8962fc0cfa13d5c7